### PR TITLE
UF-7975: Add dismiss404 for incident integration

### DIFF
--- a/src/integration-test/resources/GetOepStatusIT/__files/test3_found_in_casemanagement_but_no_match_in_casestatus_db_or_incident/mappings/incident.json
+++ b/src/integration-test/resources/GetOepStatusIT/__files/test3_found_in_casemanagement_but_no_match_in_casestatus_db_or_incident/mappings/incident.json
@@ -8,6 +8,6 @@
       "Content-Type": "application/json"
     },
     "bodyFileName": "test3_found_in_casemanagement_but_no_match_in_casestatus_db_or_incident/responses/incident.json",
-    "status": 200
+    "status": 404
   }
 }

--- a/src/integration-test/resources/GetOepStatusIT/__files/test3_found_in_casemanagement_but_no_match_in_casestatus_db_or_incident/responses/incident.json
+++ b/src/integration-test/resources/GetOepStatusIT/__files/test3_found_in_casemanagement_but_no_match_in_casestatus_db_or_incident/responses/incident.json
@@ -1,2 +1,5 @@
 {
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Incident with id: 1308f4ca-f7d6-4c88-9098-64be43b3a905 not found"
 }

--- a/src/main/java/se/sundsvall/casestatus/integration/incident/IncidentClient.java
+++ b/src/main/java/se/sundsvall/casestatus/integration/incident/IncidentClient.java
@@ -13,7 +13,8 @@ import generated.se.sundsvall.incident.IncidentOepResponse;
 @FeignClient(
         name = CLIENT_ID,
         url = "${integration.incident.base-url}",
-        configuration = IncidentConfiguration.class
+        configuration = IncidentConfiguration.class,
+        dismiss404 = true
 )
 public interface IncidentClient {
 

--- a/src/main/java/se/sundsvall/casestatus/integration/incident/IncidentIntegration.java
+++ b/src/main/java/se/sundsvall/casestatus/integration/incident/IncidentIntegration.java
@@ -25,7 +25,7 @@ public class IncidentIntegration {
         try {
             return Optional.of(client.getIncidentStatusForExternalCaseId(externalCaseId));
         } catch (Exception e) {
-            LOG.info("Unable to get incident status for external id {}", externalCaseId, e);
+            LOG.warn("Unable to get incident status for external id {}", externalCaseId, e);
 
             return Optional.empty();
         }


### PR DESCRIPTION
Adding dismiss404 on incident integration to avoid printing stacktrace for each 404. 